### PR TITLE
Add "Proefschrift" to title page

### DIFF
--- a/FrontMatter/title.tex
+++ b/FrontMatter/title.tex
@@ -204,6 +204,12 @@ All rights reserved. No part of this publication may be reproduced, stored in a 
         \bigskip
         \bigskip
 
+        
+        {\Large\titlefont Proefschrift}
+
+        %% Include some whitespace
+        \bigskip
+        \bigskip
 
 
         %%%% Required text by the doctoral degree regulations


### PR DESCRIPTION
I am not sure if the "Proefschrift" word on the titlepage is actually required, but it is included on the titlepage that you can download from myPhD. So I figured it would be a good idea to include it in the template as well.