### PR TITLE
Fix inclusion of color name in PDF TOC

### DIFF
--- a/stylesheet.tex
+++ b/stylesheet.tex
@@ -74,6 +74,13 @@
 
 \usepackage{csquotes}
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%% ~~~~ PDF Settings
+
+%% Fix inclusion of color name in PDF TOC
+\pdfstringdefDisableCommands{%
+	\def\color#1#{\@gobble}%
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% ~~~~ Crop & tick marks


### PR DESCRIPTION
Currently, the Part-Title displayed in the PDF TOC (so the TOC generally opening in the left pane of your typical PDF viewer) includes the color-name (e.g.: "thumb0 I Introduction"). This fix removes the color name from the PDF TOC.