### PR TITLE
Fixes from using the template for my thesis.

### DIFF
--- a/FrontMatter/title.tex
+++ b/FrontMatter/title.tex
@@ -216,14 +216,14 @@ All rights reserved. No part of this publication may be reproduced, stored in a 
         %% NB: be very mindfull of the lower case lettering used!!!
         %% NB: basically; do not change this bit
         ter verkrijging van de graad van doctor aan de Universiteit Utrecht\\[\medskipamount]
-        op gezag van de rector magnificus, prof.dr.\ H.R.B.M.~Kummeling,\\[\medskipamount]
+        op gezag van de rector magnificus, prof.dr.ir.\ W.~Hazeleger,\\[\medskipamount]
         ingevolge het besluit van het college voor promoties\\[\medskipamount]
         in het openbaar te verdedigen\\[\medskipamount]
         %%%% Change to relevant date for defense
         %% written as: dayofweek(text) date(number) month(text)  year(number)
         %% if in the morning use: des ochtends te XX.XX uur (use 12-hour format)
         %% if in the afternoon use: des middags te XX.XX uur (use 12-hour format)
-        op woensdag DD mmmmm YYYY  des ochtends te UU.UU uur
+        op woensdag DD mmmmm YYYY  des ochtends te U.UU uur
 
         %% Include some whitespace
         \bigskip
@@ -240,7 +240,7 @@ All rights reserved. No part of this publication may be reproduced, stored in a 
         %%%% Full name
         %% Print the full name of the author.
         {\makeatletter
-        \Large\titlefont\bfseries\@firstname~{\titleshape\@lastname}
+        \Large\titlefont\bfseries\@firstname~\@middlename~{\titleshape\@lastname}
         \makeatother}
 
 
@@ -253,6 +253,7 @@ All rights reserved. No part of this publication may be reproduced, stored in a 
 
         %%%% Change to relevant date of birth and town
         %% NB: include country if not born in the Netherlands
+        %% NB: date of birth optional due to privacy considerations
         geboren op DD month YYYY te CITY
 
 

--- a/dissertation.cls
+++ b/dissertation.cls
@@ -311,11 +311,13 @@
     %% Add the title to the PDF meta data.
     \hypersetup{pdftitle=#2}%
 }
-%% Redefine the author command to accept a first and last name, and to add the
-%% full name to the PDF meta data.
-\renewcommand*\author[2]{%
+%% Redefine the author command to accept a first, last, and middle name,
+%% and to add the full name to the PDF meta data.
+%% Middle name is used in title page.
+\renewcommand*\author[3]{%
     \def\@firstname{#1}%
     \def\@lastname{#2}%
+    \def\@middlename{#3}%
     \hypersetup{pdfauthor=#1\ #2}%
 }
 
@@ -382,17 +384,36 @@
 %% indices.
 \usetikzlibrary{calc}
 
-% Colours of the chapters
-\defineCMYKcolor{thumb0}{30,100,40,10} % uu-bordeaux
-\defineCMYKcolor{thumb1}{0,100,80,0} % uu-red
-\defineCMYKcolor{thumb2}{0,15,100,0} % uu-yellow
-\defineCMYKcolor{thumb3}{0,50,65,0} % uu-orange
-\defineCMYKcolor{thumb4}{75,8,50,0} % uu-green
-\defineCMYKcolor{thumb5}{70,40,0,0} % uu-blue
-\defineCMYKcolor{thumb6}{80,100,0,0} % uu-purple
-\defineCMYKcolor{thumb7}{100,80,0,70} % uu-darkblue
-\defineCMYKcolor{thumb8}{35,70,80,50} % uu-brown
-\defineCMYKcolor{thumb9}{0,10,40,0} % uu-creme
+%% Colours of the chapters
+%% Use CYMK for printing and RGB for not-printing (digital)
+%% Note: uu-yellow is hard to read when used for chapters
+\if@print
+    \defineCMYKcolor{thumb0}{20,0,0,100} % uu-black, hack!
+    \defineCMYKcolor{thumb1}{0,100,80,0} % uu-red
+    \defineCMYKcolor{thumb2}{30,100,40,10} % uu-burgundy
+    \defineCMYKcolor{thumb3}{0,50,65,0} % uu-orange
+    \defineCMYKcolor{thumb4}{75,8,50,0} % uu-green
+    \defineCMYKcolor{thumb5}{70,40,0,0} % uu-blue
+    \defineCMYKcolor{thumb6}{80,100,0,0} % uu-purple
+    \defineCMYKcolor{thumb7}{100,80,0,70} % uu-darkblue
+    \defineCMYKcolor{thumb8}{35,70,80,50} % uu-brown
+    \defineCMYKcolor{thumb9}{0,10,40,0} % uu-creme
+    \defineCMYKcolor{thumb10}{20,0,0,100} % uu-black
+\else
+    \definecolor{thumb0}{RGB}{0,0,0} % uu-black
+    \definecolor{thumb1}{RGB}{192,10,53} % uu-red
+    \definecolor{thumb2}{RGB}{170,21,85} % uu-burgundy
+    \definecolor{thumb3}{RGB}{243,150,94} % uu-orange
+    \definecolor{thumb4}{RGB}{36,167,147} % uu-green
+    \definecolor{thumb5}{RGB}{82,135,198} % uu-blue
+
+    \definecolor{thumb6}{RGB}{91,33,130} % uu-purple
+    \definecolor{thumb7}{RGB}{0,18,64} % uu-darkblue
+    \definecolor{thumb8}{RGB}{110,59,35} % uu-brown
+    \definecolor{thumb9}{RGB}{250,230,171} % uu-cream
+    \definecolor{thumb10}{RGB}{0,0,0} % uu-black
+
+\fi
 
 %% The lthumb command prints the current chapter number in a thumb index on the
 %% left (even) page.
@@ -411,7 +432,12 @@
             %\fill[fill=thumb,rounded corners=\thumbedge](top left) rectangle (bottom right);
             \fill[fill=thumb\arabic{colorcounter},rounded corners=\thumbedge](top left) rectangle (bottom right);
             %% Print the chapter number at the center right in the thumb index.
-            \coordinate (center right) at ($(bottom right)+(0pt,0.5\thumbheight)$);
+            %% If the number is two digit move it more to the center for printing.
+            \ifnum\value{thumbcounter}>9
+                \coordinate (center right) at ($(bottom right)+(3pt,0.5\thumbheight)$);
+            \else
+                \coordinate (center right) at ($(bottom right)+(0pt,0.5\thumbheight)$);
+            \fi
             \node at (center right)[anchor=east,inner sep=2\thumbedge]{
                 \titlefont\bfseries\color{white}
                 \fontsize{0.75\thumbheight}{0.75\thumbheight}\selectfont
@@ -437,7 +463,12 @@
             %\fill[fill=thumb,rounded corners=\thumbedge](top right) rectangle (bottom left);
             \fill[fill=thumb\arabic{colorcounter},rounded corners=\thumbedge](top right) rectangle (bottom left);
             %% Print the chapter number at the center right in the thumb index.
-            \coordinate (center left) at ($(bottom left)+(0pt,0.5\thumbheight)$);
+            %% If the number is two digit move it more to the center for printing.
+            \ifnum\value{thumbcounter}>9
+                \coordinate (center left) at ($(bottom left)+(-3pt,0.5\thumbheight)$);
+            \else
+                \coordinate (center left) at ($(bottom left)+(0pt,0.5\thumbheight)$);
+            \fi
             \node at (center left)[anchor=west,inner sep=2\thumbedge]{
                 \titlefont\bfseries\color{white}
                 \fontsize{0.75\thumbheight}{0.75\thumbheight}\selectfont
@@ -534,7 +565,7 @@
 %% in the title color.
 \titleformat{\section}
     {\Large\headerstyle}
-    {\bfseries\thesection.\ }
+    {\bfseries\thesection\ }
     {0pt}
     {\color{thumb\arabic{colorcounter}}}
 %% Sections are preceded by an empty line.
@@ -547,7 +578,7 @@
 %% font.
 \titleformat{\subsection}
     {\large\headerstyle}
-    {\bfseries\thesubsection.\ }
+    {\bfseries\thesubsection\ }
     {0pt}
     {\color{thumb\arabic{colorcounter}}}
 \titlespacing{\subsection}{0pt}{\baselineskip}{0pt}

--- a/dissertation.cls
+++ b/dissertation.cls
@@ -406,7 +406,6 @@
     \definecolor{thumb3}{RGB}{243,150,94} % uu-orange
     \definecolor{thumb4}{RGB}{36,167,147} % uu-green
     \definecolor{thumb5}{RGB}{82,135,198} % uu-blue
-
     \definecolor{thumb6}{RGB}{91,33,130} % uu-purple
     \definecolor{thumb7}{RGB}{0,18,64} % uu-darkblue
     \definecolor{thumb8}{RGB}{110,59,35} % uu-brown

--- a/main.tex
+++ b/main.tex
@@ -202,6 +202,7 @@ This meant that we could provide more in-depth insight where it was needed.
 %%%% Part-title and properties
 %% Progress the thumbcounter
 \stepcounter{thumbcounter}
+\setcounter{thumbcounter}{20}
 %% Colour to use for this part
 \setcounter{colorcounter}{2}
 %% Name and label

--- a/main.tex
+++ b/main.tex
@@ -25,7 +25,7 @@
 
 %%%% Author
 %% this will be used everywhere
-\author{Your First Names}{Lastname}
+\author{First Name}{Last Name}{Middle Name(s)}
 
 
 
@@ -202,7 +202,6 @@ This meant that we could provide more in-depth insight where it was needed.
 %%%% Part-title and properties
 %% Progress the thumbcounter
 \stepcounter{thumbcounter}
-\setcounter{thumbcounter}{20}
 %% Colour to use for this part
 \setcounter{colorcounter}{2}
 %% Name and label

--- a/stylesheet.tex
+++ b/stylesheet.tex
@@ -74,6 +74,22 @@
 
 \usepackage{csquotes}
 
+%% To have page filling vertical images always oriented to the center
+%% we turn them around if needed. packages used for oddpage.
+\usepackage{ifthen,changepage}
+
+%%Example use:
+%\begin{figure}
+%	\centering
+%    \checkoddpage
+%    \ifthenelse{\boolean{oddpage}}{
+%        \centerline{\includegraphics[width=1.0\textheight,angle=90,origin=c]{PATH}}    
+%    }{
+%        \centerline{\includegraphics[width=1.0\textheight,angle=270,origin=c]{PATH}}  
+%    }
+%	\caption{Caption}
+%	\label{Figure}
+%\end{figure}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%% ~~~~ PDF Settings
 
@@ -133,6 +149,9 @@
 % Better enumeration
 %\usepackage[inline]{enumitem}
 
+%%% set space between items and paragraphs for lists
+% \setlist[itemize]{parsep=0.0pt}
+\setlist{parsep=2pt}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -238,7 +257,7 @@
 \renewcommand{\cftpartpresnum}{\hypersetup{linkcolor=thumb\arabic{colorcounter}}}
 
 \titlecontents{part}%
-[0pt]{\color{thumb\arabic{colorcounter}}\bfseries\large\protect\addvspace{10pt}\titlerule[1pt]\addvspace{1.3ex}}
+[0pt]{\stepcounter{colorcounter}\color{thumb\arabic{colorcounter}}\bfseries\large\protect\addvspace{10pt}\titlerule[1pt]\addvspace{1.3ex}}
 {}{\partname~}
 {\hfill\contentspage}%
 [\addvspace{0.7ex} {\titlerule[1pt]} \addvspace{5pt}]%


### PR DESCRIPTION
* Fix colours for digital use by forcing RGB.
* Fix colours in ToC.
* Move thumbnumber more to the center for two digit numbers for printing.
* Add option to include middle name.
* Add template for page filling images to always face the center.
* Update Rector Magnificus
* Set space between list and paragraph for better readability
* Remove addition . after subsection number. Default is without.